### PR TITLE
Prevent appending 0x1A multiple times at the end of the file.

### DIFF
--- a/dbf.go
+++ b/dbf.go
@@ -166,7 +166,9 @@ func LoadFile(fileName string) (table *DbfTable, err error) {
 // SaveFile dbf file.
 func (dt *DbfTable) SaveFile(filename string) error {
 	// don't forget to add dbase end of file marker which is 1Ah
-	dt.dataStore = appendSlice(dt.dataStore, []byte{0x1A})
+	if dt.dataStore[len(dt.dataStore)-1] != 0x1A {
+		dt.dataStore = appendSlice(dt.dataStore, []byte{0x1A})
+	}
 	f, err := os.Create(filename)
 	if err != nil {
 		return err


### PR DESCRIPTION
This pull request addresses an issue where the 0x1A byte was consistently appended to the end of the file when the same file is saved multiple times and leading to file corruption. The fix introduces a check to prevent appending 0x1A if it already exists at the end of the file. 