### PR TITLE
Prevent multiple appending of the EOF byte at the end of the file

### DIFF
--- a/dbf.go
+++ b/dbf.go
@@ -165,8 +165,10 @@ func LoadFile(fileName string) (table *DbfTable, err error) {
 
 // SaveFile dbf file.
 func (dt *DbfTable) SaveFile(filename string) error {
-	// don't forget to add dbase end of file marker which is 1Ah
-	dt.dataStore = appendSlice(dt.dataStore, []byte{0x1A})
+	// ensure the last byte in the data store is the dBase end-of-file marker (0x1A)
+	if dt.dataStore[len(dt.dataStore)-1] != 0x1A {
+		dt.dataStore[len(dt.dataStore)-1] = 0x1A
+	}
 	f, err := os.Create(filename)
 	if err != nil {
 		return err

--- a/dbf.go
+++ b/dbf.go
@@ -53,7 +53,7 @@ type DbfField struct {
 
 // Create a new dbase table from the scratch
 func New() *DbfTable {
-	// Create and pupulate DbaseTable struct
+	// Create and populate DbaseTable struct
 	dt := new(DbfTable)
 
 	// read dbase table header information
@@ -96,7 +96,7 @@ func LoadFile(fileName string) (table *DbfTable, err error) {
 	if err != nil {
 		return nil, err
 	}
-	// Create and pupulate DbaseTable struct
+	// Create and populate DbaseTable struct
 	dt := new(DbfTable)
 	dt.loading = true
 	// set DbfTable dataStore slice that will store the complete file in memory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/Bowbaq/dbf
+module github.com/Riznyk01/dbf
 
-go 1.15
+go 1.22
 
 require (
 	github.com/pkg/errors v0.9.1


### PR DESCRIPTION
This pull request addresses an issue where the 0x1A byte was consistently appended to the end of the file when the same file is saved multiple times and leading to file corruption. The fix introduces a check to prevent appending 0x1A if it already exists at the end of the file.